### PR TITLE
Fix tag + version wrapping in addon listings

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -585,13 +585,16 @@ thead:last-child tr:last-child th:first-child, tbody:last-child tr:last-child td
     margin-bottom:2px;
   }
 
+    .addonListing header span {
+      display: inline-block;
+    }
+
 span.version,
 span.tag {
   padding: 3px 7px;
   border-radius:10px;
   color: #FFF;
   margin-right:3px;
-  vertical-align: top;
 }
 
 span.version {


### PR DESCRIPTION
When lots of tags were on a particular addon, the wrapping caused a few problems. For example:

![image](https://user-images.githubusercontent.com/37386245/115752266-d55a9180-a391-11eb-941a-b555d3bc46b9.png)

This fix causes them to instead wrap sensibly:

![image](https://user-images.githubusercontent.com/37386245/115752189-c542b200-a391-11eb-95fb-9c55c999a1c9.png)
